### PR TITLE
Add support for oculus touch controllers

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -23,8 +23,8 @@
                     </a-plane>
                 </a-entity>
 
-                <a-entity vive-controls="hand: left" teleport-controls="startEvent: down; endEvent: up; button: trackpad; collisionEntity: #floor" super-hands _physics-collider sphere-collider="objects: .grabbable" grab static-body></a-entity>
-                <a-entity vive-controls="hand: right" vive-cursor="objects: .clickable" super-hands _physics-collider sphere-collider="objects: .grabbable" grab static-body></a-entity>
+                <a-entity vive-controls="hand: left" oculus-touch-controls="hand: left" teleport-controls="startEvent: down; endEvent: up; button: trackpad; collisionEntity: #floor" super-hands _physics-collider sphere-collider="objects: .grabbable" grab static-body></a-entity>
+                <a-entity vive-controls="hand: right" oculus-touch-controls="hand: right" vive-cursor="objects: .clickable" super-hands _physics-collider sphere-collider="objects: .grabbable" grab static-body></a-entity>
             </a-entity>
 
             <a-grid src="/img/grid.png"></a-grid>


### PR DESCRIPTION
File operations seem to work.

No support for teleport controls yet as binding multiple events requires a non-trivial update to aframe-teleport-controls and aframe-master.

Also, when I tested on Oculus Quest, I had to remove `camera="userHeight: 1.6"` or my head would be high above my hands. I left that code in for now, but it should probably be removed when the dependencies are upgraded.